### PR TITLE
Parse zipped gpx files

### DIFF
--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -32,9 +32,8 @@ Future<MapViewDAO?> importCoordinatesFile(GCWFile file) async {
       if (archive.files.isNotEmpty) {
         var file = archive.first;
         file.decompress();
-        var xml =
-            convertBytesToString(Uint8List.fromList(file.content as List<int>));
-        if (file.name.endsWith('.gpx')) {
+        if (getFileExtension(file.name.toLowerCase()) == 'gpx') {
+          var xml = convertBytesToString(Uint8List.fromList(file.content as List<int>));
           return parseCoordinatesFile(xml);
         }
       }

--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -35,7 +35,11 @@ Future<MapViewDAO?> importCoordinatesFile(GCWFile file) async {
         file.decompress();
 
         var xml = convertBytesToString(Uint8List.fromList(file.content as List<int>));
-        return parseCoordinatesFile(xml, kmlFormat: true);
+        if (file.name.endsWith('.gpx')) {
+          return parseCoordinatesFile(xml);
+        } else if (file.name.endsWith('.kml')) {
+          return parseCoordinatesFile(xml, kmlFormat: true);
+        }
       }
       break;
     default:

--- a/lib/tools/coords/map_view/widget/gcw_mapview.dart
+++ b/lib/tools/coords/map_view/widget/gcw_mapview.dart
@@ -840,7 +840,7 @@ class _GCWMapViewState extends State<GCWMapView> {
         child: iconedGCWPopupMenuItem(context, Icons.drive_folder_upload, i18n(context, 'coords_openmap_loaddata')),
         action: (index) {
           setState(() {
-            showOpenFileDialog(context, [FileType.GPX, FileType.KML, FileType.KMZ, FileType.JSON], _loadCoordinatesFile);
+            showOpenFileDialog(context, [FileType.GPX, FileType.KML, FileType.KMZ, FileType.JSON, FileType.ZIP], _loadCoordinatesFile);
           });
         },
       ),


### PR DESCRIPTION
Enhances gcw_mapview.dart by adding the ability to import zipped GPX files into the map. Some geocaching apps, such as Cachly (iOS), export GPX files as zipped archives. This enhancement allows users to directly import these ZIP files, streamlining the workflow.