### PR TITLE
fix - 'gpx' to '.gpx'

### DIFF
--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -32,7 +32,7 @@ Future<MapViewDAO?> importCoordinatesFile(GCWFile file) async {
       if (archive.files.isNotEmpty) {
         var file = archive.first;
         file.decompress();
-        if (getFileExtension(file.name.toLowerCase()) == 'gpx') {
+        if (getFileExtension(file.name.toLowerCase()) == '.gpx') {
           var xml = convertBytesToString(Uint8List.fromList(file.content as List<int>));
           return parseCoordinatesFile(xml);
         }


### PR DESCRIPTION
I have no idea, where this dot in front of the suffix disappeared