### PR TITLE
added languages to ios Info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,5 +61,16 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleLocalizations</key>
+        <array>
+            <string>en</string>
+            <string>de</string>
+            <string>nl</string>
+            <string>es</string>
+            <string>ko</string>
+            <string>sk</string>
+            <string>sv</string>
+            <string>pl</string>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
We still need to update the settings in App Store Connect for the next release. The languages with a translation ratio exceeding 50% are: German (de), Dutch (nl), Spanish (es), Korean (ko), Slovak (sk), Swedish (sv), and Polish (pl).
#2067