### PR TITLE
disable ad in gold version

### DIFF
--- a/lib/application/category_views/all_tools_view.dart
+++ b/lib/application/category_views/all_tools_view.dart
@@ -329,7 +329,6 @@ class _MainViewState extends State<MainView> {
   final _searchController = TextEditingController();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   var _searchText = '';
-  bool _goldVersion = false;
   final _SHOW_SUPPORT_HINT_EVERY_N = 50;
 
   @override
@@ -380,7 +379,7 @@ class _MainViewState extends State<MainView> {
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async{
-      await _checkForGoldVersion();
+      bool goldVersion = await _checkForGoldVersion();
       var countAppOpened = Prefs.getInt(PREFERENCE_APP_COUNT_OPENED);
 
       if (countAppOpened > 1 && Prefs.getString(PREFERENCE_CHANGELOG_DISPLAYED) != CHANGELOG.keys.first) {
@@ -389,7 +388,7 @@ class _MainViewState extends State<MainView> {
         return;
       }
 
-      if (countAppOpened > 0 && !_goldVersion && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
+      if (countAppOpened > 0 && !goldVersion && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
         showGCWAlertDialog(
           context,
           i18n(context, 'common_support_title'),
@@ -408,11 +407,9 @@ class _MainViewState extends State<MainView> {
     super.dispose();
   }
 
-  Future<void> _checkForGoldVersion() async {
+  Future<bool> _checkForGoldVersion() async {
     await GCWPackageInfo.init();
-    setState(() {
-      _goldVersion = GCWPackageInfo.getInstance().appName.toLowerCase().contains('gold');
-    });
+    return GCWPackageInfo.getInstance().appName.toLowerCase().contains('gold');
   }
 
   @override

--- a/lib/application/category_views/all_tools_view.dart
+++ b/lib/application/category_views/all_tools_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gc_wizard/application/_common/gcw_package_info.dart';
 import 'package:gc_wizard/application/category_views/favorites.dart';
 import 'package:gc_wizard/application/category_views/selector_lists/babylon_numbers_selection.dart';
 import 'package:gc_wizard/application/category_views/selector_lists/base_selection.dart';
@@ -328,6 +329,7 @@ class _MainViewState extends State<MainView> {
   final _searchController = TextEditingController();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   var _searchText = '';
+  bool _goldVersion = false;
   final _SHOW_SUPPORT_HINT_EVERY_N = 50;
 
   @override
@@ -377,7 +379,8 @@ class _MainViewState extends State<MainView> {
           cancelButton: false);
     }
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async{
+      await _checkForGoldVersion();
       var countAppOpened = Prefs.getInt(PREFERENCE_APP_COUNT_OPENED);
 
       if (countAppOpened > 1 && Prefs.getString(PREFERENCE_CHANGELOG_DISPLAYED) != CHANGELOG.keys.first) {
@@ -386,7 +389,7 @@ class _MainViewState extends State<MainView> {
         return;
       }
 
-      if (countAppOpened > 0 && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
+      if (countAppOpened > 0 && !_goldVersion && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
         showGCWAlertDialog(
           context,
           i18n(context, 'common_support_title'),
@@ -403,6 +406,13 @@ class _MainViewState extends State<MainView> {
     _searchController.dispose();
 
     super.dispose();
+  }
+
+  Future<void> _checkForGoldVersion() async {
+    await GCWPackageInfo.init();
+    setState(() {
+      _goldVersion = GCWPackageInfo.getInstance().appName.toLowerCase().contains('gold');
+    });
   }
 
   @override

--- a/lib/application/category_views/all_tools_view.dart
+++ b/lib/application/category_views/all_tools_view.dart
@@ -379,8 +379,8 @@ class _MainViewState extends State<MainView> {
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async{
-      bool goldVersion = await _checkForGoldVersion();
       var countAppOpened = Prefs.getInt(PREFERENCE_APP_COUNT_OPENED);
+      bool showSupportHint = true;
 
       if (countAppOpened > 1 && Prefs.getString(PREFERENCE_CHANGELOG_DISPLAYED) != CHANGELOG.keys.first) {
         _showWhatsNewDialog();
@@ -388,7 +388,11 @@ class _MainViewState extends State<MainView> {
         return;
       }
 
-      if (countAppOpened > 0 && !goldVersion && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
+      if (countAppOpened > 0 && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
+        showSupportHint = !(await _checkForGoldVersion()) ;
+      }
+
+      if (showSupportHint) {
         showGCWAlertDialog(
           context,
           i18n(context, 'common_support_title'),

--- a/lib/application/category_views/all_tools_view.dart
+++ b/lib/application/category_views/all_tools_view.dart
@@ -380,7 +380,6 @@ class _MainViewState extends State<MainView> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) async{
       var countAppOpened = Prefs.getInt(PREFERENCE_APP_COUNT_OPENED);
-      bool showSupportHint = true;
 
       if (countAppOpened > 1 && Prefs.getString(PREFERENCE_CHANGELOG_DISPLAYED) != CHANGELOG.keys.first) {
         _showWhatsNewDialog();
@@ -389,16 +388,16 @@ class _MainViewState extends State<MainView> {
       }
 
       if (countAppOpened > 0 && (countAppOpened == 10 || countAppOpened % _SHOW_SUPPORT_HINT_EVERY_N == 0)) {
-        showSupportHint = !(await _checkForGoldVersion()) ;
-      }
-
-      if (showSupportHint) {
-        showGCWAlertDialog(
-          context,
-          i18n(context, 'common_support_title'),
-          i18n(context, 'common_support_text', parameters: [Prefs.getInt(PREFERENCE_APP_COUNT_OPENED)]),
-          () => launchUrl(Uri.parse(i18n(context, 'common_support_link'))),
-        );
+        _checkForGoldVersion().then((value) {
+          if (!value) {
+            showGCWAlertDialog(
+              context,
+              i18n(context, 'common_support_title'),
+              i18n(context, 'common_support_text', parameters: [Prefs.getInt(PREFERENCE_APP_COUNT_OPENED)]),
+                  () => launchUrl(Uri.parse(i18n(context, 'common_support_link'))),
+            );
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
This disables the ad in the gold version.
It might be better way to place a new Pref like 
`const PREFERENCE_APP_APPNAME = 'GC Wizard';
`
which is set in main.dart after  the call of 
`GCWPackageInfo.init();`
to the app name
We could avoid another async function in all_tools_view.dart 
and just call the PREFERENCE_APP_APPNAME for checking the goldversion state.