### PR TITLE
3.5.0 max char info in textfield

### DIFF
--- a/lib/common_widgets/textfields/gcw_textfield.dart
+++ b/lib/common_widgets/textfields/gcw_textfield.dart
@@ -80,43 +80,46 @@ class _GCWTextFieldState extends State<GCWTextField> {
           return TextFormField(
             autocorrect: false,
             decoration: InputDecoration(
-                hintText: widget.hintText,
-                hintStyle: gcwTextStyle().copyWith(color: widget.hintColor ?? themeColors().textFieldHintText()),
-                labelText: widget.labelText,
-                fillColor: widget.filled == true ? colors.textFieldFill() : null,
-                filled: widget.filled,
-                prefixIcon: widget.icon,
-                isDense: true,
-                suffixIconConstraints: const BoxConstraints(
-                  minWidth: 2,
-                  minHeight: 2,
+              hintText: widget.hintText,
+              hintStyle: gcwTextStyle().copyWith(color: widget.hintColor ?? themeColors().textFieldHintText()),
+              labelText: widget.labelText,
+              fillColor: widget.filled == true ? colors.textFieldFill() : null,
+              filled: widget.filled,
+              prefixIcon: widget.icon,
+              isDense: true,
+              suffixIconConstraints: const BoxConstraints(minWidth: 2, minHeight: 2),
+              suffixIcon: constraints.maxWidth > 100
+                  ? InkWell(
+                child: Container(
+                  padding: const EdgeInsets.only(right: 5, top: 5, bottom: 5),
+                  child: Icon(Icons.clear, color: colors.mainFont()),
                 ),
-                suffixIcon: constraints.maxWidth > 100
-                    ? InkWell(
-                  child: Container(
-                    padding: const EdgeInsets.only(right: 5, top: 5, bottom: 5),
-                    child: Icon(
-                      Icons.clear,
-                      color: colors.mainFont(),
-                    ),
-                  ),
-                  onTap: () {
-                    if (widget.controller != null) widget.controller?.clear();
-
-                    _controller.clear();
-
-                    if (widget.onChanged != null) widget.onChanged!('');
-
-                    if (widget.inputFormatters != null) {
-                      widget.inputFormatters?.forEach((formatter) {
-                        if (formatter is GCWMaskTextInputFormatter) {
-                          formatter.clear();
-                        }
-                      });
-                    }
+                onTap: () {
+                  widget.controller?.clear();
+                  _controller.clear();
+                  widget.onChanged?.call('');
+                  widget.inputFormatters?.forEach((f) {
+                    if (f is GCWMaskTextInputFormatter) f.clear();
+                  });
+                },
+              )
+                  : null,
+              suffix: widget.maxLength != null
+                  ? Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: ValueListenableBuilder<TextEditingValue>(
+                  valueListenable: _controller,
+                  builder: (context, value, _) {
+                    return Text(
+                      '${value.text.length}/${widget.maxLength}',
+                      style: TextStyle(color: colors.textFieldHintText(), fontSize: 12),
+                    );
                   },
-                )
-                    : null),
+                ),
+              )
+                  : null,
+              counterText: '', // verhindert den unteren Zähler
+            ),
             onChanged: widget.onChanged,
             controller: widget.controller ?? _controller,
             autovalidateMode: AutovalidateMode.always,


### PR DESCRIPTION
Old style:
![Bildschirmfoto 2025-05-24 um 09 07 58](https://github.com/user-attachments/assets/2db1e9f7-57db-42fe-a452-856cb7078e28)

New style?
![Bildschirmfoto 2025-05-24 um 09 06 51](https://github.com/user-attachments/assets/7259a1ba-90ac-4760-9e22-da692aea61e1)

This small change would make the textfield design more compact and logical, IMHO.